### PR TITLE
Target binary requires :libm to be specified explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ find_library( DL_LIB NAMES ${CMAKE_DL_LIBS} )
 target_link_libraries(vertexdb ${CMAKE_DL_LIBS})
 MESSAGE( STATUS "using dl library: ${DL_LIB}" )
 
+target_link_libraries(vertexdb m)
+MESSAGE( STATUS "using m library from the standard glibc")
+
 include_directories(source source/pdb source/httpserver source/basekit/source source/store source/basekit/source/simd_cph/include)
 
 # installing vertextdb binary


### PR DESCRIPTION
On my system (ArchLinux, cmake 2.8.11.2-2, glibc 2.18-4) the `m` library is required to explicitly specified. Otherwise, the `make` program will exist with error at the linking process.
